### PR TITLE
Add simple_admin_wrapper contract

### DIFF
--- a/shared/fa2_modules/README.md
+++ b/shared/fa2_modules/README.md
@@ -1,1 +1,44 @@
 Reusable modules to use as part of FA2 implementation.
+
+## `simple_admin`
+
+One of the possible implementations of admin API for FA2 contract.
+The admin API can change an admin address using two step confirmation pattern and
+pause/unpause the contract. Only current admin can initiate those operations.
+
+Other entry points may guard their access using helper functions
+`fail_if_not_admin` and `fail_if_paused`.
+
+### `simple_admin_wrapper`
+
+The `simple_admin_wrapper` contract includes the `simple_admin` module,
+exposing the functions `fail_if_not_admin` and  `fail_if_paused` as entrypoints:
+
+```ocaml
+type wrapper_storage = {
+  admin : simple_admin_storage;
+}
+
+type wrapper_param =
+  | Admin of simple_admin
+  | Fail_if_not_admin of unit
+  | Fail_if_paused of unit
+```
+
+The contract is located in [`test/`](test/simple_admin_wrapper.mligo)
+and it can be compiled to Michelson using the following command:
+
+```bash
+ligo compile-contract --syntax cameligo \
+  --output-file=test/out/simple_admin_wrapper.tz \
+  test/simple_admin_wrapper.mligo wrapper_main
+```
+
+Or, using `docker`:
+
+```bash
+docker run --rm -v "$PWD":"$PWD" -w "$PWD" ligolang/ligo:0.13.0 compile-contract \
+  --syntax cameligo --output-file=test/out/simple_admin_wrapper.tz \
+  test/simple_admin_wrapper.mligo wrapper_main
+```
+

--- a/shared/fa2_modules/test/out/simple_admin_wrapper.tz
+++ b/shared/fa2_modules/test/out/simple_admin_wrapper.tz
@@ -1,0 +1,77 @@
+{ parameter
+    (or (or (or %admin (or (unit %confirm_admin) (bool %pause)) (address %set_admin))
+            (unit %fail_if_not_admin))
+        (unit %fail_if_paused)) ;
+  storage (pair (pair (address %admin) (bool %paused)) (option %pending_admin address)) ;
+  code { LAMBDA
+           (pair (pair address bool) (option address))
+           unit
+           { CAR ;
+             CAR ;
+             SENDER ;
+             COMPARE ;
+             NEQ ;
+             IF { PUSH string "NOT_AN_ADMIN" ; FAILWITH } { UNIT } } ;
+         SWAP ;
+         UNPAIR ;
+         IF_LEFT
+           { IF_LEFT
+               { IF_LEFT
+                   { IF_LEFT
+                       { DROP ;
+                         SWAP ;
+                         DROP ;
+                         DUP ;
+                         CDR ;
+                         IF_NONE
+                           { DROP ; PUSH string "NO_PENDING_ADMIN" ; FAILWITH }
+                           { SENDER ;
+                             COMPARE ;
+                             EQ ;
+                             IF { NONE address ; SWAP ; CAR ; CDR ; SENDER ; PAIR ; PAIR }
+                                { DROP ; PUSH string "NOT_A_PENDING_ADMIN" ; FAILWITH } } ;
+                         NIL operation ;
+                         PAIR }
+                       { SWAP ;
+                         DUP ;
+                         DUG 2 ;
+                         DIG 3 ;
+                         SWAP ;
+                         EXEC ;
+                         DROP ;
+                         SWAP ;
+                         DUP ;
+                         DUG 2 ;
+                         CDR ;
+                         SWAP ;
+                         DIG 2 ;
+                         CAR ;
+                         CAR ;
+                         PAIR ;
+                         PAIR ;
+                         NIL operation ;
+                         PAIR } }
+                   { SWAP ;
+                     DUP ;
+                     DUG 2 ;
+                     DIG 3 ;
+                     SWAP ;
+                     EXEC ;
+                     DROP ;
+                     SOME ;
+                     SWAP ;
+                     CAR ;
+                     PAIR ;
+                     NIL operation ;
+                     PAIR } }
+               { DROP ; DUP ; DIG 2 ; SWAP ; EXEC ; DROP ; NIL operation ; PAIR } }
+           { DROP ;
+             SWAP ;
+             DROP ;
+             DUP ;
+             CAR ;
+             CDR ;
+             IF { PUSH string "PAUSED" ; FAILWITH } {} ;
+             NIL operation ;
+             PAIR } } }
+

--- a/shared/fa2_modules/test/simple_admin_wrapper.mligo
+++ b/shared/fa2_modules/test/simple_admin_wrapper.mligo
@@ -20,15 +20,15 @@ let wrapper_main
     : (operation list) * wrapper_storage =
   match param with
   | Admin p ->
-      let ops, admin = simple_admin (p, s.admin) in
-      let new_s = { s with admin = admin; } in
+      let ops, admin : (operation_list * address) = simple_admin (p, s.admin) in
+      let new_s : wrapper_storage = { s with admin = admin; } in
       (ops, new_s)
 
   | Fail_if_not_admin p ->
-      let u = fail_if_not_admin s.admin in
+      let u : unit = fail_if_not_admin s.admin in
       (([]: operation list), s)
 
   | Fail_if_paused p ->
-      let u = fail_if_paused s.admin in
+      let u : unit = fail_if_paused s.admin in
       (([]: operation list), s)
 

--- a/shared/fa2_modules/test/simple_admin_wrapper.mligo
+++ b/shared/fa2_modules/test/simple_admin_wrapper.mligo
@@ -1,0 +1,34 @@
+(*
+  Wrapper around simple_admin for testing:
+  embeds simple_admin.mligo and includes `unit` entrypoints
+  that trigger `fail_if_not_admin`, `fail_if_paused`
+*)
+
+#include "../simple_admin.mligo"
+
+type wrapper_storage = {
+  admin : simple_admin_storage;
+}
+
+type wrapper_param =
+  | Admin of simple_admin
+  | Fail_if_not_admin of unit
+  | Fail_if_paused of unit
+
+let wrapper_main
+    (param, s : wrapper_param * wrapper_storage)
+    : (operation list) * wrapper_storage =
+  match param with
+  | Admin p ->
+      let ops, admin = simple_admin (p, s.admin) in
+      let new_s = { s with admin = admin; } in
+      (ops, new_s)
+
+  | Fail_if_not_admin p ->
+      let u = fail_if_not_admin s.admin in
+      (([]: operation list), s)
+
+  | Fail_if_paused p ->
+      let u = fail_if_paused s.admin in
+      (([]: operation list), s)
+


### PR DESCRIPTION
The `simple_admin_wrapper` contract includes the `simple_admin` module and
exposes the functions `fail_if_not_admin` and  `fail_if_paused` as entrypoints.

This makes it possible to use [`mi-cho-coq`](https://gitlab.com/nomadic-labs/mi-cho-coq) to verify some of its properties.

```ocaml
type wrapper_storage = {
  admin : simple_admin_storage;
}

type wrapper_param =
  | Admin of simple_admin
  | Fail_if_not_admin of unit
  | Fail_if_paused of unit
```
